### PR TITLE
Liberando versão 'no-conflit'

### DIFF
--- a/css/buildspec.yml
+++ b/css/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    APP_VERSION: "1.0.0"
+    APP_VERSION: "1.0.1"
 
 phases:
   install:

--- a/css/helpers/src/box.less
+++ b/css/helpers/src/box.less
@@ -34,31 +34,32 @@
 
 .fnc-classname(@val, @sufix){
 
+
     
     .mar-t@{val}@{sufix}{
-        margin-top: (@val)px;
+        margin-top: ~"@{val}px";
     }
     .mar-b@{val}@{sufix}{
-        margin-bottom: (@val)px;
+        margin-bottom: ~"@{val}px";
     }
     .mar-l@{val}@{sufix}{
-        margin-left: (@val)px;
+        margin-left: ~"@{val}px";
     }
     .mar-r@{val}@{sufix}{
-        margin-right: (@val)px;
+        margin-right: ~"@{val}px";
     }
 
     .pad-t@{val}@{sufix}{
-        padding-top: (@val)px;
+        padding-top: ~"@{val}px";
     }
     .pad-b@{val}@{sufix}{
-        padding-bottom: (@val)px;
+        padding-bottom: ~"@{val}px";
     }
     .pad-l@{val}@{sufix}{
-        padding-left: (@val)px;
+        padding-left: ~"@{val}px";
     }
     .pad-r@{val}@{sufix}{
-        padding-right: (@val)px;
+        padding-right: ~"@{val}px";
     }
 
 }

--- a/css/no-conflit.less
+++ b/css/no-conflit.less
@@ -1,0 +1,3 @@
+.rhino {
+    @import url("index.less");
+}

--- a/css/readme.md
+++ b/css/readme.md
@@ -3,9 +3,9 @@ Classes do rhinoCSS
 
 # Para compilar
 
-
-
 ```
 lessc index.less dist/rhino.css
 lessc index.less dist/rhino.min.css --clean-css
 ```
+
+.


### PR DESCRIPTION
Liberando versão 'no-conflit' para utilização junto bom outros scripts (por exemplo Bootstrap).

Assim, o rhino.css só será ativado de em um elemento pai tiver a classe `.rhino`.